### PR TITLE
fix "Error: Resource pattern specifies unknown module file" build error on Gradle application

### DIFF
--- a/core/src/main/java/org/mybatis/spring/nativex/MyBatisScannedResourcesHolder.java
+++ b/core/src/main/java/org/mybatis/spring/nativex/MyBatisScannedResourcesHolder.java
@@ -18,6 +18,8 @@ package org.mybatis.spring.nativex;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.reflect.Modifier;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
@@ -281,11 +283,27 @@ public class MyBatisScannedResourcesHolder {
           path = url.replace(baseUrl, "");
         } else if (url.contains(".jar!")) {
           path = JAR_RESOURCE_PREFIX_PATTERN.matcher(url).replaceFirst("");
+        } else {
+          path = determineRelativePath(url);
         }
         return path;
       } catch (IOException e) {
         throw new UncheckedIOException(e);
       }
+    }
+
+    private String determineRelativePath(String url) {
+      Path path = Paths.get(url);
+      StringBuilder sb = new StringBuilder();
+      for (int i = path.getNameCount() - 1; i >= 0; i--) {
+        sb.insert(0, path.getName(i));
+        String relativePath = sb.toString();
+        if (RESOURCE_PATTERN_RESOLVER.getResource(relativePath).exists()) {
+          return relativePath;
+        }
+        sb.insert(0, path.getFileSystem().getSeparator());
+      }
+      return url;
     }
 
   }

--- a/core/src/main/java/org/mybatis/spring/nativex/MyBatisScannedResourcesHolder.java
+++ b/core/src/main/java/org/mybatis/spring/nativex/MyBatisScannedResourcesHolder.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.reflect.Modifier;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
@@ -284,7 +283,7 @@ public class MyBatisScannedResourcesHolder {
         } else if (url.contains(".jar!")) {
           path = JAR_RESOURCE_PREFIX_PATTERN.matcher(url).replaceFirst("");
         } else {
-          path = determineRelativePath(url);
+          path = determineRelativePath(resource);
         }
         return path;
       } catch (IOException e) {
@@ -292,8 +291,8 @@ public class MyBatisScannedResourcesHolder {
       }
     }
 
-    private String determineRelativePath(String url) {
-      Path path = Paths.get(url);
+    private String determineRelativePath(Resource resource) throws IOException {
+      Path path = resource.getFile().toPath();
       StringBuilder sb = new StringBuilder();
       for (int i = path.getNameCount() - 1; i >= 0; i--) {
         sb.insert(0, path.getName(i));
@@ -301,9 +300,9 @@ public class MyBatisScannedResourcesHolder {
         if (RESOURCE_PATTERN_RESOLVER.getResource(relativePath).exists()) {
           return relativePath;
         }
-        sb.insert(0, path.getFileSystem().getSeparator());
+        sb.insert(0, '/');
       }
-      return url;
+      return resource.getURL().toString();
     }
 
   }

--- a/core/src/test/gradle_resources/mapper/gradle_output/GradleOutputMapper.xml
+++ b/core/src/test/gradle_resources/mapper/gradle_output/GradleOutputMapper.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+
+       Copyright 2022 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="gradle.OutputMapper">
+
+  <select id="select">
+    SELECT 1
+  </select>
+
+</mapper>
+

--- a/core/src/test/java/org/mybatis/spring/nativex/MyBatisResourcesScanTest.java
+++ b/core/src/test/java/org/mybatis/spring/nativex/MyBatisResourcesScanTest.java
@@ -15,17 +15,18 @@
  */
 package org.mybatis.spring.nativex;
 
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.mybatis.spring.nativex.component.AbstractTypeHandler;
-import org.mybatis.spring.nativex.component.BarService;
-import org.mybatis.spring.nativex.component.BarTypeHandler;
-import org.mybatis.spring.nativex.component.FooTypeHandler;
-import org.mybatis.spring.nativex.component.TypeHandlers;
+import org.mybatis.spring.nativex.component.*;
 import org.mybatis.spring.nativex.component2.AnyTypeHandler;
 import org.mybatis.spring.nativex.entity.City;
 import org.mybatis.spring.nativex.entity.Country;
@@ -33,6 +34,7 @@ import org.mybatis.spring.nativex.marker.StandardEntity;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.nativex.hint.TypeAccess;
+import org.springframework.util.ClassUtils;
 
 class MyBatisResourcesScanTest {
 
@@ -181,6 +183,26 @@ class MyBatisResourcesScanTest {
   }
 
   @Test
+  void scanResourceLocationsWithGradleBuildOutput() throws Exception {
+    String currentDir = Objects.requireNonNull(getClass().getResource("")).getPath();
+    String projectDir = currentDir.substring(0, currentDir.indexOf("/target/test-classes"));
+    SimulateGradleBuildResourcesURLClassLoader classLoader = new SimulateGradleBuildResourcesURLClassLoader(
+        projectDir + "/src/test/gradle_resources/", getClass().getClassLoader());
+    ClassUtils.overrideThreadContextClassLoader(classLoader);
+    AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+    context.registerBean(ConfigurationForScanResourceLocationsWithGradleOutputResources.class);
+    context.refresh();
+    MyBatisScannedResourcesHolder holder = context.getBean(MyBatisScannedResourcesHolder.class);
+    Assertions.assertThat(holder.getTypeAliasesClasses()).isEmpty();
+    Assertions.assertThat(holder.getMapperLocations()).isEmpty();
+    Assertions.assertThat(holder.getTypeHandlerClasses()).isEmpty();
+    Assertions.assertThat(holder.getReflectionClasses()).isEmpty();
+    Assertions.assertThat(holder.getResourceLocations())
+        .containsExactlyInAnyOrder("mapper/gradle_output/GradleOutputMapper.xml");
+    Assertions.assertThat(holder.getReflectionTypeAccesses()).isEmpty();
+  }
+
+  @Test
   void scanResourceLocationsWithMultiPattern() {
     AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
     context.registerBean(ConfigurationForScanResourceLocationsWithMultiPattern.class);
@@ -277,6 +299,11 @@ class MyBatisResourcesScanTest {
   static class ConfigurationForScanResourceLocations {
   }
 
+  @MyBatisResourcesScan(resourceLocationPatterns = { "mapper/gradle_output/*.*" })
+  @Configuration
+  static class ConfigurationForScanResourceLocationsWithGradleOutputResources {
+  }
+
   @MyBatisResourcesScan(resourceLocationPatterns = { "mapper/sub2/*.*", "org/apache/ibatis/builder/xml/*.dtd" })
   @Configuration
   static class ConfigurationForScanResourceLocationsWithMultiPattern {
@@ -289,6 +316,20 @@ class MyBatisResourcesScanTest {
   @MyBatisResourcesScan(resourceLocationPatterns = "mapper/sub2/*.*")
   @Configuration
   static class ConfigurationForRepeat {
+
+  }
+
+  private static class SimulateGradleBuildResourcesURLClassLoader extends URLClassLoader {
+
+    public SimulateGradleBuildResourcesURLClassLoader(String path, ClassLoader classLoader)
+        throws MalformedURLException {
+      super(new URL[] { new File(path).toURI().toURL() }, classLoader);
+    }
+
+    @Override
+    public void addURL(URL url) {
+      super.addURL(url);
+    }
 
   }
 

--- a/core/src/test/java/org/mybatis/spring/nativex/MyBatisResourcesScanTest.java
+++ b/core/src/test/java/org/mybatis/spring/nativex/MyBatisResourcesScanTest.java
@@ -26,7 +26,11 @@ import java.util.stream.Stream;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.mybatis.spring.nativex.component.*;
+import org.mybatis.spring.nativex.component.AbstractTypeHandler;
+import org.mybatis.spring.nativex.component.BarService;
+import org.mybatis.spring.nativex.component.BarTypeHandler;
+import org.mybatis.spring.nativex.component.FooTypeHandler;
+import org.mybatis.spring.nativex.component.TypeHandlers;
 import org.mybatis.spring.nativex.component2.AnyTypeHandler;
 import org.mybatis.spring.nativex.entity.City;
 import org.mybatis.spring.nativex.entity.Country;


### PR DESCRIPTION
By default, gradle outputs generated source files into build/classes directory and outputs resources files into build/resources directory. That makes the mapper url cannot be replaced by "baseUrl" https://github.com/mybatis/spring-native/blob/213199e554625cea86f50a4b552ba8ec48c0db7c/core/src/main/java/org/mybatis/spring/nativex/MyBatisScannedResourcesHolder.java#L280.

Gradle outputs layout:
```
/proj
    /build
        /classes             // baseUrl start with /proj/build/classes
        /resources         // fooMapper.xml start with /proj/build/resources
```

Maven outputs layout
```
/proj
    /target
        /classes            // both baseUrl and fooMapper.xml start with /proj/target/classes
```
  