### PR TITLE
Cleanup poms with move to native maven plugin to plugin management

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2022 the original author or authors.
+       Copyright 2022-2023 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -24,7 +24,6 @@
     <groupId>org.mybatis.spring.native</groupId>
     <artifactId>mybatis-spring-native</artifactId>
     <version>0.1.0-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>mybatis-spring-native-core</artifactId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2022 the original author or authors.
+       Copyright 2022-2023 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -24,7 +24,6 @@
     <groupId>org.mybatis.spring.native</groupId>
     <artifactId>mybatis-spring-native</artifactId>
     <version>0.1.0-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>mybatis-spring-native-docs</artifactId>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2022 the original author or authors.
+       Copyright 2022-2023 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -24,7 +24,6 @@
     <groupId>org.mybatis.spring.native</groupId>
     <artifactId>mybatis-spring-native</artifactId>
     <version>0.1.0-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>mybatis-spring-native-extensions</artifactId>

--- a/samples/cache/pom.xml
+++ b/samples/cache/pom.xml
@@ -24,7 +24,6 @@
     <groupId>org.mybatis.spring.native</groupId>
     <artifactId>mybatis-spring-native-samples</artifactId>
     <version>0.1.0-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>mybatis-spring-native-sample-cache</artifactId>
   <name>mybatis-spring-native-sample-cache</name>

--- a/samples/cache/pom.xml
+++ b/samples/cache/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2022 the original author or authors.
+       Copyright 2022-2023 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.

--- a/samples/cache/pom.xml
+++ b/samples/cache/pom.xml
@@ -121,7 +121,6 @@
       <id>native</id>
       <properties>
         <repackage.classifier>exec</repackage.classifier>
-        <native-buildtools.version>0.9.13</native-buildtools.version>
       </properties>
       <dependencies>
         <dependency>
@@ -135,7 +134,6 @@
           <plugin>
             <groupId>org.graalvm.buildtools</groupId>
             <artifactId>native-maven-plugin</artifactId>
-            <version>${native-buildtools.version}</version>
             <extensions>true</extensions>
             <configuration>
               <buildArgs>

--- a/samples/configuration/pom.xml
+++ b/samples/configuration/pom.xml
@@ -24,7 +24,6 @@
     <groupId>org.mybatis.spring.native</groupId>
     <artifactId>mybatis-spring-native-samples</artifactId>
     <version>0.1.0-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>mybatis-spring-native-sample-configuration</artifactId>
   <name>mybatis-spring-native-sample-configuration</name>

--- a/samples/configuration/pom.xml
+++ b/samples/configuration/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2022 the original author or authors.
+       Copyright 2022-2023 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.

--- a/samples/configuration/pom.xml
+++ b/samples/configuration/pom.xml
@@ -121,7 +121,6 @@
       <id>native</id>
       <properties>
         <repackage.classifier>exec</repackage.classifier>
-        <native-buildtools.version>0.9.13</native-buildtools.version>
       </properties>
       <dependencies>
         <dependency>
@@ -135,7 +134,6 @@
           <plugin>
             <groupId>org.graalvm.buildtools</groupId>
             <artifactId>native-maven-plugin</artifactId>
-            <version>${native-buildtools.version}</version>
             <extensions>true</extensions>
             <executions>
               <execution>

--- a/samples/dao/pom.xml
+++ b/samples/dao/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2022 the original author or authors.
+       Copyright 2022-2023 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.

--- a/samples/dao/pom.xml
+++ b/samples/dao/pom.xml
@@ -121,7 +121,6 @@
       <id>native</id>
       <properties>
         <repackage.classifier>exec</repackage.classifier>
-        <native-buildtools.version>0.9.13</native-buildtools.version>
       </properties>
       <dependencies>
         <dependency>
@@ -135,7 +134,6 @@
           <plugin>
             <groupId>org.graalvm.buildtools</groupId>
             <artifactId>native-maven-plugin</artifactId>
-            <version>${native-buildtools.version}</version>
             <extensions>true</extensions>
             <executions>
               <execution>

--- a/samples/dao/pom.xml
+++ b/samples/dao/pom.xml
@@ -24,7 +24,6 @@
     <groupId>org.mybatis.spring.native</groupId>
     <artifactId>mybatis-spring-native-samples</artifactId>
     <version>0.1.0-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>mybatis-spring-native-sample-dao</artifactId>
   <name>mybatis-spring-native-sample-dao</name>

--- a/samples/dynamic-sql/pom.xml
+++ b/samples/dynamic-sql/pom.xml
@@ -125,7 +125,6 @@
       <id>native</id>
       <properties>
         <repackage.classifier>exec</repackage.classifier>
-        <native-buildtools.version>0.9.13</native-buildtools.version>
       </properties>
       <dependencies>
         <dependency>
@@ -139,7 +138,6 @@
           <plugin>
             <groupId>org.graalvm.buildtools</groupId>
             <artifactId>native-maven-plugin</artifactId>
-            <version>${native-buildtools.version}</version>
             <extensions>true</extensions>
             <executions>
               <execution>

--- a/samples/dynamic-sql/pom.xml
+++ b/samples/dynamic-sql/pom.xml
@@ -24,7 +24,6 @@
     <groupId>org.mybatis.spring.native</groupId>
     <artifactId>mybatis-spring-native-samples</artifactId>
     <version>0.1.0-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>mybatis-spring-native-sample-dynamic-sql</artifactId>
   <name>mybatis-spring-native-sample-dynamic-sql</name>

--- a/samples/dynamic-sql/pom.xml
+++ b/samples/dynamic-sql/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2022 the original author or authors.
+       Copyright 2022-2023 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.

--- a/samples/freemarker/pom.xml
+++ b/samples/freemarker/pom.xml
@@ -125,7 +125,6 @@
       <id>native</id>
       <properties>
         <repackage.classifier>exec</repackage.classifier>
-        <native-buildtools.version>0.9.13</native-buildtools.version>
       </properties>
       <dependencies>
         <dependency>
@@ -139,7 +138,6 @@
           <plugin>
             <groupId>org.graalvm.buildtools</groupId>
             <artifactId>native-maven-plugin</artifactId>
-            <version>${native-buildtools.version}</version>
             <extensions>true</extensions>
             <executions>
               <execution>

--- a/samples/freemarker/pom.xml
+++ b/samples/freemarker/pom.xml
@@ -24,7 +24,6 @@
     <groupId>org.mybatis.spring.native</groupId>
     <artifactId>mybatis-spring-native-samples</artifactId>
     <version>0.1.0-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>mybatis-spring-native-sample-freemarker</artifactId>
   <name>mybatis-spring-native-sample-freemarker</name>

--- a/samples/freemarker/pom.xml
+++ b/samples/freemarker/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2022 the original author or authors.
+       Copyright 2022-2023 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -24,7 +24,6 @@
     <groupId>org.mybatis.spring.native</groupId>
     <artifactId>mybatis-spring-native</artifactId>
     <version>0.1.0-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>mybatis-spring-native-samples</artifactId>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2022 the original author or authors.
+       Copyright 2022-2023 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -36,11 +36,9 @@
     <maven.deploy.skip>true</maven.deploy.skip>
     <maven.test.skip>true</maven.test.skip>
     <maven.site.skip>true</maven.site.skip>
+
+    <native-buildtools.version>0.9.13</native-buildtools.version>
   </properties>
-  
-  <build>
-    <finalName>${project.artifactId}</finalName>
-  </build>
 
   <modules>
     <module>simple</module>
@@ -57,4 +55,17 @@
     <module>dynamic-sql</module>
   </modules>
 
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.graalvm.buildtools</groupId>
+          <artifactId>native-maven-plugin</artifactId>
+          <version>${native-buildtools.version}</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
+    <finalName>${project.artifactId}</finalName>
+  </build>
 </project>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -31,7 +31,6 @@
   <packaging>pom</packaging>
 
   <properties>
-    <animal.sniffer.skip>true</animal.sniffer.skip>
     <enforcer.skip>true</enforcer.skip>
     <maven.deploy.skip>true</maven.deploy.skip>
     <maven.test.skip>true</maven.test.skip>

--- a/samples/scan/pom.xml
+++ b/samples/scan/pom.xml
@@ -24,7 +24,6 @@
     <groupId>org.mybatis.spring.native</groupId>
     <artifactId>mybatis-spring-native-samples</artifactId>
     <version>0.1.0-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>mybatis-spring-native-sample-scan</artifactId>
   <name>mybatis-spring-native-sample-scan</name>

--- a/samples/scan/pom.xml
+++ b/samples/scan/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2022 the original author or authors.
+       Copyright 2022-2023 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.

--- a/samples/scan/pom.xml
+++ b/samples/scan/pom.xml
@@ -121,7 +121,6 @@
       <id>native</id>
       <properties>
         <repackage.classifier>exec</repackage.classifier>
-        <native-buildtools.version>0.9.13</native-buildtools.version>
       </properties>
       <dependencies>
         <dependency>
@@ -135,7 +134,6 @@
           <plugin>
             <groupId>org.graalvm.buildtools</groupId>
             <artifactId>native-maven-plugin</artifactId>
-            <version>${native-buildtools.version}</version>
             <extensions>true</extensions>
             <executions>
               <execution>

--- a/samples/simple/pom.xml
+++ b/samples/simple/pom.xml
@@ -24,7 +24,6 @@
     <groupId>org.mybatis.spring.native</groupId>
     <artifactId>mybatis-spring-native-samples</artifactId>
     <version>0.1.0-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>mybatis-spring-native-sample-simple</artifactId>
   <name>mybatis-spring-native-sample-simple</name>

--- a/samples/simple/pom.xml
+++ b/samples/simple/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2022 the original author or authors.
+       Copyright 2022-2023 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.

--- a/samples/simple/pom.xml
+++ b/samples/simple/pom.xml
@@ -121,7 +121,6 @@
       <id>native</id>
       <properties>
         <repackage.classifier>exec</repackage.classifier>
-        <native-buildtools.version>0.9.13</native-buildtools.version>
       </properties>
       <dependencies>
         <dependency>
@@ -135,7 +134,6 @@
           <plugin>
             <groupId>org.graalvm.buildtools</groupId>
             <artifactId>native-maven-plugin</artifactId>
-            <version>${native-buildtools.version}</version>
             <extensions>true</extensions>
             <executions>
               <execution>

--- a/samples/sqlprovider/pom.xml
+++ b/samples/sqlprovider/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2022 the original author or authors.
+       Copyright 2022-2023 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.

--- a/samples/sqlprovider/pom.xml
+++ b/samples/sqlprovider/pom.xml
@@ -24,7 +24,6 @@
     <groupId>org.mybatis.spring.native</groupId>
     <artifactId>mybatis-spring-native-samples</artifactId>
     <version>0.1.0-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>mybatis-spring-native-sample-sqlprovider</artifactId>
   <name>mybatis-spring-native-sample-sqlprovider</name>

--- a/samples/sqlprovider/pom.xml
+++ b/samples/sqlprovider/pom.xml
@@ -121,7 +121,6 @@
       <id>native</id>
       <properties>
         <repackage.classifier>exec</repackage.classifier>
-        <native-buildtools.version>0.9.13</native-buildtools.version>
       </properties>
       <dependencies>
         <dependency>
@@ -135,7 +134,6 @@
           <plugin>
             <groupId>org.graalvm.buildtools</groupId>
             <artifactId>native-maven-plugin</artifactId>
-            <version>${native-buildtools.version}</version>
             <extensions>true</extensions>
             <executions>
               <execution>

--- a/samples/thymeleaf-sqlgenerator/pom.xml
+++ b/samples/thymeleaf-sqlgenerator/pom.xml
@@ -125,7 +125,6 @@
       <id>native</id>
       <properties>
         <repackage.classifier>exec</repackage.classifier>
-        <native-buildtools.version>0.9.13</native-buildtools.version>
       </properties>
       <dependencies>
         <dependency>
@@ -139,7 +138,6 @@
           <plugin>
             <groupId>org.graalvm.buildtools</groupId>
             <artifactId>native-maven-plugin</artifactId>
-            <version>${native-buildtools.version}</version>
             <extensions>true</extensions>
             <executions>
               <execution>

--- a/samples/thymeleaf-sqlgenerator/pom.xml
+++ b/samples/thymeleaf-sqlgenerator/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2022 the original author or authors.
+       Copyright 2022-2023 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.

--- a/samples/thymeleaf-sqlgenerator/pom.xml
+++ b/samples/thymeleaf-sqlgenerator/pom.xml
@@ -24,7 +24,6 @@
     <groupId>org.mybatis.spring.native</groupId>
     <artifactId>mybatis-spring-native-samples</artifactId>
     <version>0.1.0-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>mybatis-spring-native-sample-thymeleaf-sqlgenerator</artifactId>
   <name>mybatis-spring-native-sample-thymeleaf-sqlgenerator</name>

--- a/samples/thymeleaf/pom.xml
+++ b/samples/thymeleaf/pom.xml
@@ -24,7 +24,6 @@
     <groupId>org.mybatis.spring.native</groupId>
     <artifactId>mybatis-spring-native-samples</artifactId>
     <version>0.1.0-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>mybatis-spring-native-sample-thymeleaf</artifactId>
   <name>mybatis-spring-native-sample-thymeleaf</name>

--- a/samples/thymeleaf/pom.xml
+++ b/samples/thymeleaf/pom.xml
@@ -125,7 +125,6 @@
       <id>native</id>
       <properties>
         <repackage.classifier>exec</repackage.classifier>
-        <native-buildtools.version>0.9.13</native-buildtools.version>
       </properties>
       <dependencies>
         <dependency>
@@ -139,7 +138,6 @@
           <plugin>
             <groupId>org.graalvm.buildtools</groupId>
             <artifactId>native-maven-plugin</artifactId>
-            <version>${native-buildtools.version}</version>
             <extensions>true</extensions>
             <executions>
               <execution>

--- a/samples/thymeleaf/pom.xml
+++ b/samples/thymeleaf/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2022 the original author or authors.
+       Copyright 2022-2023 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.

--- a/samples/velocity/pom.xml
+++ b/samples/velocity/pom.xml
@@ -125,7 +125,6 @@
       <id>native</id>
       <properties>
         <repackage.classifier>exec</repackage.classifier>
-        <native-buildtools.version>0.9.13</native-buildtools.version>
       </properties>
       <dependencies>
         <dependency>
@@ -139,7 +138,6 @@
           <plugin>
             <groupId>org.graalvm.buildtools</groupId>
             <artifactId>native-maven-plugin</artifactId>
-            <version>${native-buildtools.version}</version>
             <extensions>true</extensions>
             <executions>
               <execution>

--- a/samples/velocity/pom.xml
+++ b/samples/velocity/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2022 the original author or authors.
+       Copyright 2022-2023 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.

--- a/samples/velocity/pom.xml
+++ b/samples/velocity/pom.xml
@@ -24,7 +24,6 @@
     <groupId>org.mybatis.spring.native</groupId>
     <artifactId>mybatis-spring-native-samples</artifactId>
     <version>0.1.0-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>mybatis-spring-native-sample-velocity</artifactId>
   <name>mybatis-spring-native-sample-velocity</name>

--- a/samples/xml/pom.xml
+++ b/samples/xml/pom.xml
@@ -24,7 +24,6 @@
     <groupId>org.mybatis.spring.native</groupId>
     <artifactId>mybatis-spring-native-samples</artifactId>
     <version>0.1.0-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>mybatis-spring-native-sample-xml</artifactId>
   <name>mybatis-spring-native-sample-xml</name>

--- a/samples/xml/pom.xml
+++ b/samples/xml/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2022 the original author or authors.
+       Copyright 2022-2023 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.

--- a/samples/xml/pom.xml
+++ b/samples/xml/pom.xml
@@ -121,7 +121,6 @@
       <id>native</id>
       <properties>
         <repackage.classifier>exec</repackage.classifier>
-        <native-buildtools.version>0.9.13</native-buildtools.version>
       </properties>
       <dependencies>
         <dependency>
@@ -135,7 +134,6 @@
           <plugin>
             <groupId>org.graalvm.buildtools</groupId>
             <artifactId>native-maven-plugin</artifactId>
-            <version>${native-buildtools.version}</version>
             <extensions>true</extensions>
             <executions>
               <execution>


### PR DESCRIPTION
suspect due to profile that is not always active, renovate cannot see it needs to update plugin, left at same version along with some other minor cleanup.  Will see if renovate pushes PR after to latest.